### PR TITLE
Add forwarders for explicit sentence embeddings

### DIFF
--- a/evaluate_with_extraction/forwarding/forward_sentence_embedder_fewnerd.py
+++ b/evaluate_with_extraction/forwarding/forward_sentence_embedder_fewnerd.py
@@ -1,0 +1,56 @@
+import os
+import json
+from typing import Dict
+
+from clearml import Dataset
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
+
+# ID of the sentence embedder used for forwarding
+EMBEDDER_ID = "nvidia/NV-Embed-v2"
+
+DATASET_NAME = "span_extraction_results.json"
+DATASET_PROJECT = "fewnerd_pipeline"
+OUTPUT_FILE = "sentence_embeddings.json"
+
+
+def load_dataset() -> Dict[str, Dict]:
+    """Download the extraction dataset from ClearML and return it."""
+    ds = Dataset.get(dataset_name=DATASET_NAME, dataset_project=DATASET_PROJECT)
+    path = os.path.join(ds.get_local_copy(), DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def upload_result(path: str) -> None:
+    """Upload the resulting embedding dataset to ClearML."""
+    cl_ds = Dataset.create(dataset_name=path, dataset_project=DATASET_PROJECT)
+    cl_ds.add_files(path=path)
+    cl_ds.add_tags([path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="FewNERD sentence embedder forward",
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate"],
+    )
+
+    embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)
+
+    records = load_dataset()
+    result = forward_dataset(records, embedder, batch_size=BATCH_SIZE)
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        json.dump(result, fh)
+
+    upload_result(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/forwarding/forward_sentence_embedder_multiconer.py
+++ b/evaluate_with_extraction/forwarding/forward_sentence_embedder_multiconer.py
@@ -1,0 +1,56 @@
+import os
+import json
+from typing import Dict
+
+from clearml import Dataset
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
+
+# ID of the sentence embedder used for forwarding
+EMBEDDER_ID = "nvidia/NV-Embed-v2"
+
+DATASET_NAME = "span_extraction_results.json"
+DATASET_PROJECT = "multiconer_pipeline"
+OUTPUT_FILE = "sentence_embeddings.json"
+
+
+def load_dataset() -> Dict[str, Dict]:
+    """Download the extraction dataset from ClearML and return it."""
+    ds = Dataset.get(dataset_name=DATASET_NAME, dataset_project=DATASET_PROJECT)
+    path = os.path.join(ds.get_local_copy(), DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def upload_result(path: str) -> None:
+    """Upload the resulting embedding dataset to ClearML."""
+    cl_ds = Dataset.create(dataset_name=path, dataset_project=DATASET_PROJECT)
+    cl_ds.add_files(path=path)
+    cl_ds.add_tags([path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="MultiCoNER sentence embedder forward",
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate"],
+    )
+
+    embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)
+
+    records = load_dataset()
+    result = forward_dataset(records, embedder, batch_size=BATCH_SIZE)
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        json.dump(result, fh)
+
+    upload_result(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/forwarding/sentence_embedder_forwarder.py
+++ b/evaluate_with_extraction/forwarding/sentence_embedder_forwarder.py
@@ -1,0 +1,38 @@
+from typing import Dict, List, Tuple
+
+from sentence_embedder import SentenceEmbedder
+
+BATCH_SIZE = 32
+
+
+def _forward_batch(batch: List[str], embedder: SentenceEmbedder) -> List[List[float]]:
+    """Forward a batch of sentences through the embedder."""
+    embeddings = embedder.forward_passage(batch)
+    return [emb.cpu().tolist() for emb in embeddings]
+
+
+def forward_dataset(
+    records: Dict[str, Dict],
+    embedder: SentenceEmbedder,
+    batch_size: int = BATCH_SIZE,
+) -> Dict[str, List[float]]:
+    """Generate an embedding for each record using the sentence embedder."""
+    result: Dict[str, List[float]] = {}
+    batch: List[Tuple[str, str]] = []
+
+    for text_id, record in records.items():
+        batch.append((text_id, record["sentence"]))
+        if len(batch) >= batch_size:
+            sentences = [text for _, text in batch]
+            embs = _forward_batch(sentences, embedder)
+            for (tid, _), emb in zip(batch, embs):
+                result[tid] = emb
+            batch = []
+
+    if batch:
+        sentences = [text for _, text in batch]
+        embs = _forward_batch(sentences, embedder)
+        for (tid, _), emb in zip(batch, embs):
+            result[tid] = emb
+
+    return result


### PR DESCRIPTION
## Summary
- set a fixed NV-Embed sentence embedder in the FewNERD forwarder
- add a new MultiCoNER forwarder using the same sentence embedder

## Testing
- `python -m py_compile evaluate_with_extraction/forwarding/forward_sentence_embedder_fewnerd.py evaluate_with_extraction/forwarding/forward_sentence_embedder_multiconer.py evaluate_with_extraction/forwarding/sentence_embedder_forwarder.py`

------
https://chatgpt.com/codex/tasks/task_e_686d084e2fec832f8a9e4acf0ccb9d83