### PR TITLE
Switch BM25 evaluation to bm25s

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ einops
 info-nce-pytorch
 faiss-cpu
 
-rank_bm25
+bm25s


### PR DESCRIPTION
## Summary
- switch BM25 library to `bm25s` for FewNERD evaluation
- update tokenization, indexing, and retrieval accordingly
- update requirement to install `bm25s`

## Testing
- `python -m py_compile evaluate_with_extraction/evaluation/fewnerd_r_precision_bm25.py`

------
https://chatgpt.com/codex/tasks/task_e_686d20b29638832f8d90a048307f17b7