### PR TITLE
Include offsets for gold spans

### DIFF
--- a/evaluate_with_extraction/extracting/base_extractor.py
+++ b/evaluate_with_extraction/extracting/base_extractor.py
@@ -179,6 +179,8 @@ class LLMExtractionRunner:
                     preds_pos = self.extract_fn(b_sents[i], generated)
                     for p in preds_pos:
                         assert b_sents[i][p["start"] : p["end"]] == p["text"]
+                    for g in b_gold_l[i]:
+                        assert b_sents[i][g["start"] : g["end"]] == g["text"]
                     preds_txt = {p["text"].strip() for p in preds_pos if p["text"].strip()}
 
                     gold_total += len(b_gold_set[i])

--- a/evaluate_with_extraction/extracting/extracting_entities_nertrieve.py
+++ b/evaluate_with_extraction/extracting/extracting_entities_nertrieve.py
@@ -77,7 +77,14 @@ def gold_spans(document: dict) -> Tuple[List[Dict[str, str]], Set[str]]:
                     index_start = sum(len(word) for word in tokens[:word_index_start]) + word_index_start
                     index_end = index_start + len(" ".join(tokens[min(ref) : max(ref) + 1]))
                     if sentence[index_start:index_end].lower() == phrase.lower():
-                        spans.append({"text": phrase, "fine_type": entity_type})
+                        spans.append(
+                            {
+                                "text": phrase,
+                                "fine_type": entity_type,
+                                "start": index_start,
+                                "end": index_end,
+                            }
+                        )
     return spans, {d["text"] for d in spans}
 
 


### PR DESCRIPTION
## Summary
- compute offsets for gold spans from dataset tokens instead of searching the text
- remove `add_gold_offsets` and store gold offsets directly in dataset helpers
- check that gold offsets match the sentence

## Testing
- `python -m py_compile evaluate_with_extraction/extracting/base_extractor.py`
- `python -m py_compile evaluate_with_extraction/extracting/extracting_entities_fewnerd.py`
- `python -m py_compile evaluate_with_extraction/extracting/extracting_entities_multiconer.py`
- `python -m py_compile evaluate_with_extraction/extracting/extracting_entities_nertrieve.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686d3f2e1070832f80d9c6b10a1eddb8