### PR TITLE
Add E5 embedder script for multiconer and rename NV forwarder

### DIFF
--- a/evaluate_with_extraction/forwarding/forward_fewnerd_intfloat_e5_mistral_7b_instruct.py
+++ b/evaluate_with_extraction/forwarding/forward_fewnerd_intfloat_e5_mistral_7b_instruct.py
@@ -1,0 +1,56 @@
+import os
+import json
+from typing import Dict
+
+from clearml import Dataset
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
+
+# ID of the sentence embedder used for forwarding
+EMBEDDER_ID = "intfloat/e5-mistral-7b-instruct"
+
+DATASET_NAME = "span_extraction_results.json"
+DATASET_PROJECT = "fewnerd_pipeline"
+OUTPUT_FILE = "sentence_embeddings_e5.json"
+
+
+def load_dataset() -> Dict[str, Dict]:
+    """Download the extraction dataset from ClearML and return it."""
+    ds = Dataset.get(dataset_name=DATASET_NAME, dataset_project=DATASET_PROJECT)
+    path = os.path.join(ds.get_local_copy(), DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def upload_result(path: str) -> None:
+    """Upload the resulting embedding dataset to ClearML."""
+    cl_ds = Dataset.create(dataset_name=path, dataset_project=DATASET_PROJECT)
+    cl_ds.add_files(path=path)
+    cl_ds.add_tags([path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="FewNERD sentence embedder forward E5",
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate", "einops"],
+    )
+
+    embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)
+
+    records = load_dataset()
+    result = forward_dataset(records, embedder, batch_size=BATCH_SIZE)
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        json.dump(result, fh)
+
+    upload_result(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/forwarding/forward_fewnerd_nv_embed_v2.py
+++ b/evaluate_with_extraction/forwarding/forward_fewnerd_nv_embed_v2.py
@@ -12,8 +12,8 @@ from sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
 EMBEDDER_ID = "nvidia/NV-Embed-v2"
 
 DATASET_NAME = "span_extraction_results.json"
-DATASET_PROJECT = "multiconer_pipeline"
-OUTPUT_FILE = "sentence_embeddings.json"
+DATASET_PROJECT = "fewnerd_pipeline"
+OUTPUT_FILE = "sentence_embeddings_nv.json"
 
 
 def load_dataset() -> Dict[str, Dict]:
@@ -36,9 +36,9 @@ def upload_result(path: str) -> None:
 
 def main() -> None:
     clearml_poc.clearml_init(
-        task_name="MultiCoNER sentence embedder forward",
+        task_name="FewNERD sentence embedder forward NV",
         project_name=DATASET_PROJECT,
-        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate"],
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate", "einops"],
     )
 
     embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)

--- a/evaluate_with_extraction/forwarding/forward_multiconer_intfloat_e5_mistral_7b_instruct.py
+++ b/evaluate_with_extraction/forwarding/forward_multiconer_intfloat_e5_mistral_7b_instruct.py
@@ -9,11 +9,11 @@ from sentence_embedder import SentenceEmbedder
 from sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
 
 # ID of the sentence embedder used for forwarding
-EMBEDDER_ID = "nvidia/NV-Embed-v2"
+EMBEDDER_ID = "intfloat/e5-mistral-7b-instruct"
 
 DATASET_NAME = "span_extraction_results.json"
-DATASET_PROJECT = "fewnerd_pipeline"
-OUTPUT_FILE = "sentence_embeddings.json"
+DATASET_PROJECT = "multiconer_pipeline"
+OUTPUT_FILE = "sentence_embeddings_e5.json"
 
 
 def load_dataset() -> Dict[str, Dict]:
@@ -36,9 +36,9 @@ def upload_result(path: str) -> None:
 
 def main() -> None:
     clearml_poc.clearml_init(
-        task_name="FewNERD sentence embedder forward",
+        task_name="MultiCoNER sentence embedder forward E5",
         project_name=DATASET_PROJECT,
-        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate", "einops"],
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate"],
     )
 
     embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)

--- a/evaluate_with_extraction/forwarding/forward_multiconer_nv_embed_v2.py
+++ b/evaluate_with_extraction/forwarding/forward_multiconer_nv_embed_v2.py
@@ -1,0 +1,56 @@
+import os
+import json
+from typing import Dict
+
+from clearml import Dataset
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
+
+# ID of the sentence embedder used for forwarding
+EMBEDDER_ID = "nvidia/NV-Embed-v2"
+
+DATASET_NAME = "span_extraction_results.json"
+DATASET_PROJECT = "multiconer_pipeline"
+OUTPUT_FILE = "sentence_embeddings_nv.json"
+
+
+def load_dataset() -> Dict[str, Dict]:
+    """Download the extraction dataset from ClearML and return it."""
+    ds = Dataset.get(dataset_name=DATASET_NAME, dataset_project=DATASET_PROJECT)
+    path = os.path.join(ds.get_local_copy(), DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def upload_result(path: str) -> None:
+    """Upload the resulting embedding dataset to ClearML."""
+    cl_ds = Dataset.create(dataset_name=path, dataset_project=DATASET_PROJECT)
+    cl_ds.add_files(path=path)
+    cl_ds.add_tags([path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="MultiCoNER sentence embedder forward NV",
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate"],
+    )
+
+    embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)
+
+    records = load_dataset()
+    result = forward_dataset(records, embedder, batch_size=BATCH_SIZE)
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        json.dump(result, fh)
+
+    upload_result(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- split the MultiCoNER sentence embedder forwarder into two scripts
- new script `forward_sentence_embedder_multiconer_intfloat_e5_mistral_7b_instruct.py`
- rename original NV script to `forward_sentence_embedder_multiconer_nv_embed_v2.py`
- adjust output filenames and ClearML task names to match the embedder
- shorten forwarder script filenames by removing `sentence_embedder`

## Testing
- `python -m py_compile evaluate_with_extraction/forwarding/forward_fewnerd_intfloat_e5_mistral_7b_instruct.py evaluate_with_extraction/forwarding/forward_fewnerd_nv_embed_v2.py evaluate_with_extraction/forwarding/forward_multiconer_intfloat_e5_mistral_7b_instruct.py evaluate_with_extraction/forwarding/forward_multiconer_nv_embed_v2.py evaluate_with_extraction/forwarding/sentence_embedder_forwarder.py`

------
https://chatgpt.com/codex/tasks/task_e_686d4969abac832f8058679b1888dfc6