### PR TITLE
Add non-other R-precision metrics

### DIFF
--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_r_precision_bm25.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_r_precision_bm25.py
@@ -12,6 +12,13 @@ from tqdm import tqdm
 import clearml_poc
 from contrastive import fewnerd_processor
 
+OTHER_MULTICONER = {"OtherLOC", "OtherPER", "OtherPROD"}
+
+
+def _is_other(fine_type: str) -> bool:
+    """Return True if the fine type represents an "other" category."""
+    return fine_type.endswith("-other") or fine_type in OTHER_MULTICONER
+
 
 class FewNerdRPrecisionBM25:
     """Evaluate FewNERD retrieval using BM25 and R-precision."""
@@ -87,8 +94,27 @@ class FewNerdRPrecisionBM25:
             rows[fine_type] = row
 
         df = pd.DataFrame.from_dict(rows, orient="index")
-        clearml_poc.add_table(title="R-precision per fine type", series="r_precision", iteration=0, table=df)
-        clearml_poc.add_table(title="average R-precision", series="r_precision", iteration=0, table=df.mean().to_frame())
+        clearml_poc.add_table(
+            title="R-precision per fine type",
+            series="r_precision",
+            iteration=0,
+            table=df,
+        )
+        clearml_poc.add_table(
+            title="average R-precision",
+            series="r_precision",
+            iteration=0,
+            table=df.mean().to_frame(),
+        )
+
+        non_other = df[~df.index.to_series().apply(_is_other)]
+        if not non_other.empty:
+            clearml_poc.add_table(
+                title="average non-other R-precision",
+                series="r_precision",
+                iteration=0,
+                table=non_other.mean().to_frame(),
+            )
         return df
 
 

--- a/evaluate_with_extraction/evaluation/multi_vecor_r_precision.py
+++ b/evaluate_with_extraction/evaluation/multi_vecor_r_precision.py
@@ -5,6 +5,13 @@ from typing import Dict, Iterable, Sequence, Set, Union
 
 import clearml_poc
 
+OTHER_MULTICONER = {"OtherLOC", "OtherPER", "OtherPROD"}
+
+
+def _is_other(fine_type: str) -> bool:
+    """Return True if the fine type represents an "other" category."""
+    return fine_type.endswith("-other") or fine_type in OTHER_MULTICONER
+
 Vector = Union[Sequence[float], np.ndarray]
 
 
@@ -92,6 +99,26 @@ class MultiVecorRPrecision:
             rows[ft] = row
 
         df = pd.DataFrame.from_dict(rows, orient="index")
-        clearml_poc.add_table(title="R-precision per fine type", series="r_precision", iteration=0, table=df)
-        clearml_poc.add_table(title="average R-precision", series="r_precision", iteration=0, table=df.mean().to_frame())
+        clearml_poc.add_table(
+            title="R-precision per fine type",
+            series="r_precision",
+            iteration=0,
+            table=df,
+        )
+
+        clearml_poc.add_table(
+            title="average R-precision",
+            series="r_precision",
+            iteration=0,
+            table=df.mean().to_frame(),
+        )
+
+        non_other = df[~df.index.to_series().apply(_is_other)]
+        if not non_other.empty:
+            clearml_poc.add_table(
+                title="average non-other R-precision",
+                series="r_precision",
+                iteration=0,
+                table=non_other.mean().to_frame(),
+            )
         return df


### PR DESCRIPTION
## Summary
- add helper `_is_other` in retrieval evaluators
- report average non-other R-precision in retrieval evaluations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f7c241720832f8abf1a91364beb4f