### PR TITLE
Switch ablation embedding files to torch binary

### DIFF
--- a/evaluate_with_extraction/ablation/forward_entity_ablation.py
+++ b/evaluate_with_extraction/ablation/forward_entity_ablation.py
@@ -124,9 +124,8 @@ def main() -> None:
             else:
                 result[k] = v
 
-    output_path = "ablation_embeddings.json"
-    with open(output_path, "w", encoding="utf-8") as fh:
-        json.dump(result, fh)
+    output_path = "ablation_embeddings.pt"
+    torch.save(result, output_path)
 
     cl_ds = Dataset.create(dataset_name=output_path, dataset_project="fewnerd_pipeline")
     cl_ds.add_files(path=output_path)

--- a/evaluate_with_extraction/ablation/forward_final_layer.py
+++ b/evaluate_with_extraction/ablation/forward_final_layer.py
@@ -94,9 +94,8 @@ def main() -> None:
             else:
                 result[k] = v
 
-    output_path = "final_layer_embeddings.json"
-    with open(output_path, "w", encoding="utf-8") as fh:
-        json.dump(result, fh)
+    output_path = "final_layer_embeddings.pt"
+    torch.save(result, output_path)
 
     cl_ds = Dataset.create(dataset_name=output_path, dataset_project="fewnerd_pipeline")
     cl_ds.add_files(path=output_path)

--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_ablation_r_precision.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_ablation_r_precision.py
@@ -24,9 +24,8 @@ def _load_dataset(name: str) -> str:
 
 
 def load_embeddings() -> Dict[str, Dict[str, List[torch.Tensor]]]:
-    path = _load_dataset("ablation_embeddings.json")
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
+    path = _load_dataset("ablation_embeddings.pt")
+    data = torch.load(path)
     result: Dict[str, Dict[str, List[torch.Tensor]]] = {}
     for tid, embs in data.items():
         for key, lst in embs.items():

--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_final_layer_r_precision.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_final_layer_r_precision.py
@@ -21,9 +21,8 @@ def _load_dataset(name: str) -> str:
 
 
 def load_embeddings() -> Dict[str, List[torch.Tensor]]:
-    path = _load_dataset("final_layer_embeddings.json")
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
+    path = _load_dataset("final_layer_embeddings.pt")
+    data = torch.load(path)
     result: Dict[str, List[torch.Tensor]] = {}
     for tid, embs in data.items():
         result[tid] = [torch.tensor(e, dtype=torch.float) for e in embs.get("llama_3_entire_model_entity_end", [])]


### PR DESCRIPTION
## Summary
- save ablation embeddings with `torch.save`
- load ablation embeddings with `torch.load`

## Testing
- `python -m py_compile evaluate_with_extraction/ablation/forward_entity_ablation.py evaluate_with_extraction/ablation/forward_final_layer.py evaluate_with_extraction/evaluation/fewnerd/fewnerd_ablation_r_precision.py evaluate_with_extraction/evaluation/fewnerd/fewnerd_final_layer_r_precision.py`

------
https://chatgpt.com/codex/tasks/task_e_6873ad0e9fec832f95db2102c8643a44