### PR TITLE
Ensure clearml tables keep results for each embedding

### DIFF
--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_ablation_r_precision.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_ablation_r_precision.py
@@ -100,7 +100,7 @@ def main() -> None:
             fine_type_to_ids=ft_to_ids,
         )
         clearml_poc.add_text(key)
-        evaluator.evaluate()
+        evaluator.evaluate(description=key)
 
 
 if __name__ == "__main__":

--- a/evaluate_with_extraction/evaluation/multi_vecor_r_precision.py
+++ b/evaluate_with_extraction/evaluation/multi_vecor_r_precision.py
@@ -66,7 +66,7 @@ class MultiVecorRPrecision:
         D, I = self.index.search(queries, 4 * len(self.index_to_tid))
         return D, I
 
-    def evaluate(self) -> pd.DataFrame:
+    def evaluate(self, description: str = "") -> pd.DataFrame:
         rows = {}
         D, I = self._search_all()
         for idx_ft, ft in enumerate(self.fine_types):
@@ -99,15 +99,16 @@ class MultiVecorRPrecision:
             rows[ft] = row
 
         df = pd.DataFrame.from_dict(rows, orient="index")
+        suffix = f" ({description})" if description else ""
         clearml_poc.add_table(
-            title="R-precision per fine type",
+            title=f"R-precision per fine type{suffix}",
             series="r_precision",
             iteration=0,
             table=df,
         )
 
         clearml_poc.add_table(
-            title="average R-precision",
+            title=f"average R-precision{suffix}",
             series="r_precision",
             iteration=0,
             table=df.mean().to_frame(),
@@ -116,7 +117,7 @@ class MultiVecorRPrecision:
         non_other = df[~df.index.to_series().apply(_is_other)]
         if not non_other.empty:
             clearml_poc.add_table(
-                title="average non-other R-precision",
+                title=f"average non-other R-precision{suffix}",
                 series="r_precision",
                 iteration=0,
                 table=non_other.mean().to_frame(),

--- a/evaluate_with_extraction/evaluation/single_vector_r_precision.py
+++ b/evaluate_with_extraction/evaluation/single_vector_r_precision.py
@@ -63,7 +63,7 @@ class SingleVectorRPrecision:
         D, I = self.index.search(queries, 4 * len(self.index_to_tid))
         return D, I
 
-    def evaluate(self) -> pd.DataFrame:
+    def evaluate(self, description: str = "") -> pd.DataFrame:
         rows = {}
         D, I = self._search_all()
         for idx_ft, ft in enumerate(self.fine_types):
@@ -87,15 +87,16 @@ class SingleVectorRPrecision:
             rows[ft] = row
 
         df = pd.DataFrame.from_dict(rows, orient="index")
+        suffix = f" ({description})" if description else ""
         clearml_poc.add_table(
-            title="R-precision per fine type",
+            title=f"R-precision per fine type{suffix}",
             series="r_precision",
             iteration=0,
             table=df,
         )
 
         clearml_poc.add_table(
-            title="average R-precision",
+            title=f"average R-precision{suffix}",
             series="r_precision",
             iteration=0,
             table=df.mean().to_frame(),
@@ -104,7 +105,7 @@ class SingleVectorRPrecision:
         non_other = df[~df.index.to_series().apply(_is_other)]
         if not non_other.empty:
             clearml_poc.add_table(
-                title="average non-other R-precision",
+                title=f"average non-other R-precision{suffix}",
                 series="r_precision",
                 iteration=0,
                 table=non_other.mean().to_frame(),


### PR DESCRIPTION
## Summary
- allow `MultiVecorRPrecision` and `SingleVectorRPrecision` to add a custom description to table titles
- append the embedding key when evaluating ablation R‑precision so each set of tables has a unique title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e8b5597c832fb53e7f549d0b6650