### PR TITLE
Add dataset splitting for NERtrieve extraction

### DIFF
--- a/evaluate_with_extraction/extracting/dispatch_nertrieve_extraction_parts.py
+++ b/evaluate_with_extraction/extracting/dispatch_nertrieve_extraction_parts.py
@@ -1,0 +1,18 @@
+from clearml import Task
+import clearml_helper
+
+N_PARTS = 20
+BASE_TASK_NAME = "CascadeNER − NERtrieve Extraction"
+PROJECT = "nertrieve_pipeline"
+QUEUE = "a100_gpu"
+
+if __name__ == "__main__":
+    for i in range(N_PARTS):
+        task = clearml_helper.get_task_by_description(
+            description=BASE_TASK_NAME,
+            new_project=PROJECT,
+        )
+        task.name = f"{BASE_TASK_NAME} part {i+1}/{N_PARTS}"
+        conf = {"split_count": N_PARTS, "split_index": i}
+        task.connect(conf, name="split")
+        task.enqueue(task, queue_name=QUEUE)


### PR DESCRIPTION
## Summary
- update `extracting_entities_nertrieve.py` to get split params from ClearML
- move dispatcher script next to extractor scripts

## Testing
- `python -m py_compile evaluate_with_extraction/extracting/extracting_entities_nertrieve.py evaluate_with_extraction/extracting/dispatch_nertrieve_extraction_parts.py`

------
https://chatgpt.com/codex/tasks/task_e_687794b94808832fae22a1907ff4244d