### PR TITLE
Exclude short FewNERD sentences from evaluation

### DIFF
--- a/evaluate_with_extraction/ablation/forward_entity_ablation.py
+++ b/evaluate_with_extraction/ablation/forward_entity_ablation.py
@@ -22,7 +22,12 @@ def load_dataset() -> Dict[str, Dict]:
     ds = Dataset.get(dataset_name="span_extraction_results.json", dataset_project="fewnerd_pipeline")
     path = os.path.join(ds.get_local_copy(), "span_extraction_results.json")
     with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data: Dict[str, Dict] = json.load(fh)
+    return {
+        tid: rec
+        for tid, rec in data.items()
+        if len(rec.get("sentence", "").split()) > 4
+    }
 
 
 def process_batch(

--- a/evaluate_with_extraction/ablation/forward_final_layer.py
+++ b/evaluate_with_extraction/ablation/forward_final_layer.py
@@ -18,7 +18,12 @@ def load_dataset() -> Dict[str, Dict]:
     ds = Dataset.get(dataset_name="span_extraction_results.json", dataset_project="fewnerd_pipeline")
     path = os.path.join(ds.get_local_copy(), "span_extraction_results.json")
     with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data: Dict[str, Dict] = json.load(fh)
+    return {
+        tid: rec
+        for tid, rec in data.items()
+        if len(rec.get("sentence", "").split()) > 4
+    }
 
 
 def process_batch(

--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_e5_mistral_evaluator.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_e5_mistral_evaluator.py
@@ -20,19 +20,25 @@ def _load_dataset(name: str) -> str:
     return os.path.join(ds.get_local_copy(), name)
 
 
-def load_embeddings() -> Dict[str, torch.Tensor]:
+def load_embeddings(valid_ids: Set[str]) -> Dict[str, torch.Tensor]:
     path = _load_dataset("sentence_embeddings_e5.pth")
     data = torch.load(path)
     result: Dict[str, torch.Tensor] = {}
     for tid, emb in tqdm(data.items(), desc="Loading embeddings"):
-        result[tid] = torch.tensor(emb, dtype=torch.float)
+        if tid in valid_ids:
+            result[tid] = torch.tensor(emb, dtype=torch.float)
     return result
 
 
 def load_metadata() -> Dict[str, Dict]:
     path = _load_dataset("span_extraction_results.json")
     with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data: Dict[str, Dict] = json.load(fh)
+    return {
+        tid: rec
+        for tid, rec in data.items()
+        if len(rec.get("sentence", "").split()) > 4
+    }
 
 
 def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:
@@ -63,7 +69,7 @@ def main() -> None:
     metadata = load_metadata()
     ft_to_ids = calc_fine_type_to_ids(metadata)
     ft_embeds = embed_fine_types(ft_to_ids)
-    embeddings = load_embeddings()
+    embeddings = load_embeddings(set(metadata.keys()))
     evaluator = SingleVectorRPrecision(
         embeddings=embeddings,
         fine_type_embeddings=ft_embeds,

--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_e5_mistral_filtered_evaluator.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_e5_mistral_filtered_evaluator.py
@@ -34,8 +34,12 @@ def load_metadata() -> Dict[str, Dict]:
     path = _load_dataset("span_extraction_results.json")
     with open(path, "r", encoding="utf-8") as fh:
         data: Dict[str, Dict] = json.load(fh)
-    # remove records without any gold labels
-    return {tid: rec for tid, rec in data.items() if rec.get("gold")}
+    # remove records without any gold labels and very short sentences
+    return {
+        tid: rec
+        for tid, rec in data.items()
+        if rec.get("gold") and len(rec.get("sentence", "").split()) > 4
+    }
 
 
 def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:

--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_r_precision_bm25.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_r_precision_bm25.py
@@ -46,8 +46,12 @@ class FewNerdRPrecisionBM25:
     def _load_metadata(self) -> Dict[str, Dict]:
         path = self._load_dataset("span_extraction_results.json")
         with open(path, "r", encoding="utf-8") as fh:
-            result = json.load(fh)
-        return result
+            data: Dict[str, Dict] = json.load(fh)
+        return {
+            tid: rec
+            for tid, rec in data.items()
+            if len(rec.get("sentence", "").split()) > 4
+        }
 
     def _calc_fine_type_to_ids(self) -> Dict[str, set]:
         mapping: Dict[str, set] = defaultdict(set)

--- a/evaluate_with_extraction/evaluation/fewnerd/fewnerd_r_precision_gold.py
+++ b/evaluate_with_extraction/evaluation/fewnerd/fewnerd_r_precision_gold.py
@@ -22,19 +22,25 @@ def _load_dataset(name: str) -> str:
     return os.path.join(ds.get_local_copy(), name)
 
 
-def load_embeddings() -> Dict[str, List[torch.Tensor]]:
+def load_embeddings(valid_ids: Set[str]) -> Dict[str, List[torch.Tensor]]:
     path = _load_dataset("llm_mlp_embeddings_gold.pth")
     data = torch.load(path)
     result: Dict[str, List[torch.Tensor]] = {}
     for tid, emb_list in tqdm(data.items(), desc="Loading embeddings"):
-        result[tid] = [torch.tensor(e, dtype=torch.float) for e in emb_list]
+        if tid in valid_ids:
+            result[tid] = [torch.tensor(e, dtype=torch.float) for e in emb_list]
     return result
 
 
 def load_metadata() -> Dict[str, Dict]:
     path = _load_dataset("span_extraction_results.json")
     with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data: Dict[str, Dict] = json.load(fh)
+    return {
+        tid: rec
+        for tid, rec in data.items()
+        if len(rec.get("sentence", "").split()) > 4
+    }
 
 
 def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:
@@ -74,7 +80,7 @@ def main() -> None:
     clearml_poc.clearml_init(task_name="FewNERD R-Precision GOLD Evaluation", project_name="fewnerd_pipeline")
     mlp_id = FineTuneLLM.mlp_head_model_id_from_clearml
     metadata = load_metadata()
-    embeddings = load_embeddings()
+    embeddings = load_embeddings(set(metadata.keys()))
     ft_to_ids = calc_fine_type_to_ids(metadata)
     ft_embeds = embed_fine_types(ft_to_ids, mlp_id)
     evaluator = MultiVecorRPrecision(


### PR DESCRIPTION
## Summary
- filter out FewNERD records with four words or fewer
- ignore short records when loading embeddings for evaluations
- apply same filter when preparing ablation embeddings and final layer forwarding

## Testing
- `python -m py_compile evaluate_with_extraction/evaluation/fewnerd/*.py evaluate_with_extraction/ablation/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6878c2fa3bdc832fa4e960c54b4dcd72