### PR TITLE
Add nertrieve forwarding & retrieval evaluation

### DIFF
--- a/evaluate_with_extraction/evaluation/nertrieve/nertrieve_e5_mistral_evaluator.py
+++ b/evaluate_with_extraction/evaluation/nertrieve/nertrieve_e5_mistral_evaluator.py
@@ -1,0 +1,78 @@
+import json
+import os
+from collections import defaultdict
+from typing import Dict, Set
+
+import torch
+from clearml import Dataset
+from tqdm import tqdm
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from evaluate_with_extraction.evaluation.single_vector_r_precision import SingleVectorRPrecision
+from clearml_pipelines.nertreieve_dataset import nertrieve_processor
+
+SENTENCE_EMBEDDER_ID = "intfloat/e5-mistral-7b-instruct"
+DATASET_PROJECT = "nertrieve_pipeline"
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+
+
+def _load_dataset(name: str) -> str:
+    ds = Dataset.get(dataset_name=name, dataset_project=DATASET_PROJECT)
+    return os.path.join(ds.get_local_copy(), name)
+
+
+def load_embeddings() -> Dict[str, torch.Tensor]:
+    path = _load_dataset("sentence_embeddings_e5.pth")
+    data = torch.load(path)
+    result: Dict[str, torch.Tensor] = {}
+    for tid, emb in tqdm(data.items(), desc="Loading embeddings"):
+        result[tid] = torch.tensor(emb, dtype=torch.float)
+    return result
+
+
+def load_metadata() -> Dict[str, Dict]:
+    path = _load_dataset(DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:
+    mapping: Dict[str, Set[str]] = defaultdict(set)
+    for tid, record in metadata.items():
+        for g in record.get("gold", []):
+            mapping[g["fine_type"]].add(tid)
+    return mapping
+
+
+def embed_fine_types(fine_type_to_ids: Dict[str, Set[str]]) -> Dict[str, torch.Tensor]:
+    embedder = SentenceEmbedder(llm_id=SENTENCE_EMBEDDER_ID)
+    type_map = nertrieve_processor.type_to_name()
+    result = {}
+    for fine_type in fine_type_to_ids.keys():
+        readable = type_map.get(fine_type, fine_type)
+        emb = embedder.forward_query(readable)[0].cpu()
+        result[fine_type] = emb
+    return result
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="NERtrieve Sentence R-Precision Evaluation " + SENTENCE_EMBEDDER_ID,
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate", "einops"],
+    )
+    metadata = load_metadata()
+    embeddings = load_embeddings()
+    ft_to_ids = calc_fine_type_to_ids(metadata)
+    ft_embeds = embed_fine_types(ft_to_ids)
+    evaluator = SingleVectorRPrecision(
+        embeddings=embeddings,
+        fine_type_embeddings=ft_embeds,
+        fine_type_to_ids=ft_to_ids,
+    )
+    evaluator.evaluate()
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/evaluation/nertrieve/nertrieve_nv_embed_v2_evaluator.py
+++ b/evaluate_with_extraction/evaluation/nertrieve/nertrieve_nv_embed_v2_evaluator.py
@@ -1,0 +1,78 @@
+import json
+import os
+from collections import defaultdict
+from typing import Dict, Set
+
+import torch
+from clearml import Dataset
+from tqdm import tqdm
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from evaluate_with_extraction.evaluation.single_vector_r_precision import SingleVectorRPrecision
+from clearml_pipelines.nertreieve_dataset import nertrieve_processor
+
+SENTENCE_EMBEDDER_ID = "nvidia/NV-Embed-v2"
+DATASET_PROJECT = "nertrieve_pipeline"
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+
+
+def _load_dataset(name: str) -> str:
+    ds = Dataset.get(dataset_name=name, dataset_project=DATASET_PROJECT)
+    return os.path.join(ds.get_local_copy(), name)
+
+
+def load_embeddings() -> Dict[str, torch.Tensor]:
+    path = _load_dataset("sentence_embeddings_nv.pth")
+    data = torch.load(path)
+    result: Dict[str, torch.Tensor] = {}
+    for tid, emb in tqdm(data.items(), desc="Loading embeddings"):
+        result[tid] = torch.tensor(emb, dtype=torch.float)
+    return result
+
+
+def load_metadata() -> Dict[str, Dict]:
+    path = _load_dataset(DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:
+    mapping: Dict[str, Set[str]] = defaultdict(set)
+    for tid, record in metadata.items():
+        for g in record.get("gold", []):
+            mapping[g["fine_type"]].add(tid)
+    return mapping
+
+
+def embed_fine_types(fine_type_to_ids: Dict[str, Set[str]]) -> Dict[str, torch.Tensor]:
+    embedder = SentenceEmbedder(llm_id=SENTENCE_EMBEDDER_ID)
+    type_map = nertrieve_processor.type_to_name()
+    result = {}
+    for fine_type in fine_type_to_ids.keys():
+        readable = type_map.get(fine_type, fine_type)
+        emb = embedder.forward_query(readable)[0].cpu()
+        result[fine_type] = emb
+    return result
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="NERtrieve Sentence R-Precision Evaluation " + SENTENCE_EMBEDDER_ID,
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate", "einops"],
+    )
+    metadata = load_metadata()
+    embeddings = load_embeddings()
+    ft_to_ids = calc_fine_type_to_ids(metadata)
+    ft_embeds = embed_fine_types(ft_to_ids)
+    evaluator = SingleVectorRPrecision(
+        embeddings=embeddings,
+        fine_type_embeddings=ft_embeds,
+        fine_type_to_ids=ft_to_ids,
+    )
+    evaluator.evaluate()
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_bm25.py
+++ b/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_bm25.py
@@ -1,0 +1,113 @@
+import json
+import os
+from collections import defaultdict
+from typing import Dict, List
+
+import Stemmer
+import pandas as pd
+from clearml import Dataset
+import bm25s
+from tqdm import tqdm
+
+import clearml_poc
+from clearml_pipelines.nertreieve_dataset import nertrieve_processor
+
+DATASET_PROJECT = "nertrieve_pipeline"
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+
+
+def _load_dataset(name: str) -> str:
+    ds = Dataset.get(dataset_name=name, dataset_project=DATASET_PROJECT)
+    return os.path.join(ds.get_local_copy(), name)
+
+
+class NertrieveRPrecisionBM25:
+    def __init__(self) -> None:
+        print("Loading metadata...")
+        self.metadata = self._load_metadata()
+        print("Metadata loaded.")
+        self.type_to_name = nertrieve_processor.type_to_name()
+        print("Calculating fine type to IDs mapping...")
+        self.fine_type_to_ids = self._calc_fine_type_to_ids()
+        print("Fine type to IDs mapping calculated.")
+        print("Preparing BM25 corpus...")
+        self.corpus_tokens, self.text_ids = self._prepare_corpus()
+        self.bm25 = bm25s.BM25()
+        self.bm25.index(self.corpus_tokens)
+        print("BM25 corpus ready.")
+        self.fine_types = list(self.fine_type_to_ids.keys())
+
+    def _load_metadata(self) -> Dict[str, Dict]:
+        path = _load_dataset(DATASET_NAME)
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _calc_fine_type_to_ids(self) -> Dict[str, set]:
+        mapping: Dict[str, set] = defaultdict(set)
+        for tid, record in self.metadata.items():
+            for g in record.get("gold", []):
+                mapping[g["fine_type"]].add(tid)
+        return mapping
+
+    def _prepare_corpus(self) -> tuple[List[List[str]], List[str]]:
+        corpus: List[str] = []
+        text_ids: List[str] = []
+        for tid, record in self.metadata.items():
+            corpus.append(record["sentence"])
+            text_ids.append(tid)
+        corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=stemmer)
+        return corpus_tokens, text_ids
+
+    def evaluate(self) -> pd.DataFrame:
+        rows = {}
+        for fine_type in tqdm(self.fine_types):
+            query_text = self.type_to_name.get(fine_type, fine_type)
+            query_tokens = bm25s.tokenize(query_text, stopwords="en", stemmer=stemmer, show_progress=False)
+            relevant = self.fine_type_to_ids[fine_type]
+            count_type = len(relevant)
+            max_k = max(500, count_type)
+            results, _scores = self.bm25.retrieve(query_tokens=query_tokens, k=max_k, show_progress=False)
+            ranking = [self.text_ids[idx] for idx in results[0]]
+
+            row = {"size": count_type}
+            sizes = [10, 50, 100, 200, 500, count_type]
+            desc = ["10", "50", "100", "200", "500", "size"]
+            for s, d in zip(sizes, desc):
+                k = min(s, count_type)
+                retrieved_k = ranking[:k]
+                hits = len(set(retrieved_k) & relevant)
+                recall = hits / count_type if count_type else 0.0
+                precision = hits / k if k else 0.0
+                row[f"recall@{d}"] = recall
+                row[f"precision@{d}"] = precision
+                if d == "size":
+                    r_prec = precision
+
+            row["R-precision"] = r_prec
+            rows[fine_type] = row
+
+        df = pd.DataFrame.from_dict(rows, orient="index")
+        clearml_poc.add_table(
+            title="R-precision per fine type",
+            series="r_precision",
+            iteration=0,
+            table=df,
+        )
+        clearml_poc.add_table(
+            title="average R-precision",
+            series="r_precision",
+            iteration=0,
+            table=df.mean().to_frame(),
+        )
+        return df
+
+
+def main() -> None:
+    clearml_poc.clearml_init(task_name="NERtrieve R-Precision BM25 Evaluation", project_name=DATASET_PROJECT)
+    evaluator = NertrieveRPrecisionBM25()
+    evaluator.evaluate()
+
+
+if __name__ == "__main__":
+    stemmer = Stemmer.Stemmer("english")
+    main()

--- a/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_gold.py
+++ b/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_gold.py
@@ -1,0 +1,91 @@
+import json
+import os
+from collections import defaultdict
+from typing import Dict, List, Set
+
+import torch
+from clearml import Dataset
+from tqdm import tqdm
+
+import clearml_poc
+import clearml_helper
+from llm_interface import LLMInterface
+from contrastive import fewnerd_processor
+from contrastive.args import Arguments, FineTuneLLM
+from clearml_pipelines.nertreieve_dataset import nertrieve_processor
+from evaluate_with_extraction.evaluation.multi_vecor_r_precision import MultiVecorRPrecision
+
+DATASET_PROJECT = "nertrieve_pipeline"
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+
+
+def _load_dataset(name: str) -> str:
+    ds = Dataset.get(dataset_name=name, dataset_project=DATASET_PROJECT)
+    return os.path.join(ds.get_local_copy(), name)
+
+
+def load_embeddings() -> Dict[str, List[torch.Tensor]]:
+    path = _load_dataset("llm_mlp_embeddings_gold.pth")
+    data = torch.load(path)
+    result: Dict[str, List[torch.Tensor]] = {}
+    for tid, emb_list in tqdm(data.items(), desc="Loading embeddings"):
+        result[tid] = [torch.tensor(e, dtype=torch.float) for e in emb_list]
+    return result
+
+
+def load_metadata() -> Dict[str, Dict]:
+    path = _load_dataset(DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:
+    mapping: Dict[str, Set[str]] = defaultdict(set)
+    for tid, record in metadata.items():
+        for g in record.get("gold", []):
+            mapping[g["fine_type"]].add(tid)
+    return mapping
+
+
+def embed_fine_types(fine_type_to_ids: Dict[str, Set[str]], mlp_id: str) -> Dict[str, torch.Tensor]:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    mlp = clearml_helper.get_mlp_by_id(mlp_id, device=device)
+    args: Arguments = clearml_helper.get_args_by_mlp_id(mlp_id)
+    llm = LLMInterface(llm_id=FineTuneLLM.llm_id, max_llm_layer=FineTuneLLM.max_llm_layer)
+    layer = FineTuneLLM.layer
+    name_map = nertrieve_processor.type_to_name()
+
+    result = {}
+    for fine_type in fine_type_to_ids.keys():
+        readable = name_map.get(fine_type, fine_type)
+        tokens = llm.tokenize(readable).to(device)
+        with torch.no_grad():
+            hidden = llm.get_llm_at_layer(tokens, layer=layer)
+        start = hidden[0, 0]
+        end = hidden[0, -1]
+        rep = fewnerd_processor.choose_llm_representation(
+            end=end.cpu().tolist(), start=start.cpu().tolist(), input_tokens=args.input_tokens
+        )
+        with torch.no_grad():
+            emb = mlp(rep.to(device)).cpu()
+        result[fine_type] = emb
+    return result
+
+
+def main() -> None:
+    clearml_poc.clearml_init(task_name="NERtrieve R-Precision GOLD Evaluation", project_name=DATASET_PROJECT)
+    mlp_id = FineTuneLLM.mlp_head_model_id_from_clearml
+    metadata = load_metadata()
+    embeddings = load_embeddings()
+    ft_to_ids = calc_fine_type_to_ids(metadata)
+    ft_embeds = embed_fine_types(ft_to_ids, mlp_id)
+    evaluator = MultiVecorRPrecision(
+        embeddings=embeddings,
+        fine_type_embeddings=ft_embeds,
+        fine_type_to_ids=ft_to_ids,
+    )
+    evaluator.evaluate()
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_prediciton.py
+++ b/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_prediciton.py
@@ -1,0 +1,91 @@
+import json
+import os
+from collections import defaultdict
+from typing import Dict, List, Set
+
+import torch
+from clearml import Dataset
+from tqdm import tqdm
+
+import clearml_poc
+import clearml_helper
+from llm_interface import LLMInterface
+from contrastive import fewnerd_processor
+from contrastive.args import Arguments, FineTuneLLM
+from clearml_pipelines.nertreieve_dataset import nertrieve_processor
+from evaluate_with_extraction.evaluation.multi_vecor_r_precision import MultiVecorRPrecision
+
+DATASET_PROJECT = "nertrieve_pipeline"
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+
+
+def _load_dataset(name: str) -> str:
+    ds = Dataset.get(dataset_name=name, dataset_project=DATASET_PROJECT)
+    return os.path.join(ds.get_local_copy(), name)
+
+
+def load_embeddings() -> Dict[str, List[torch.Tensor]]:
+    path = _load_dataset("llm_mlp_embeddings.pth")
+    data = torch.load(path)
+    result: Dict[str, List[torch.Tensor]] = {}
+    for tid, emb_list in tqdm(data.items(), desc="Loading embeddings"):
+        result[tid] = [torch.tensor(e, dtype=torch.float) for e in emb_list]
+    return result
+
+
+def load_metadata() -> Dict[str, Dict]:
+    path = _load_dataset(DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:
+    mapping: Dict[str, Set[str]] = defaultdict(set)
+    for tid, record in metadata.items():
+        for g in record.get("gold", []):
+            mapping[g["fine_type"]].add(tid)
+    return mapping
+
+
+def embed_fine_types(fine_type_to_ids: Dict[str, Set[str]], mlp_id: str) -> Dict[str, torch.Tensor]:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    mlp = clearml_helper.get_mlp_by_id(mlp_id, device=device)
+    args: Arguments = clearml_helper.get_args_by_mlp_id(mlp_id)
+    llm = LLMInterface(llm_id=FineTuneLLM.llm_id, max_llm_layer=FineTuneLLM.max_llm_layer)
+    layer = FineTuneLLM.layer
+    name_map = nertrieve_processor.type_to_name()
+
+    result = {}
+    for fine_type in fine_type_to_ids.keys():
+        readable = name_map.get(fine_type, fine_type)
+        tokens = llm.tokenize(readable).to(device)
+        with torch.no_grad():
+            hidden = llm.get_llm_at_layer(tokens, layer=layer)
+        start = hidden[0, 0]
+        end = hidden[0, -1]
+        rep = fewnerd_processor.choose_llm_representation(
+            end=end.cpu().tolist(), start=start.cpu().tolist(), input_tokens=args.input_tokens
+        )
+        with torch.no_grad():
+            emb = mlp(rep.to(device)).cpu()
+        result[fine_type] = emb
+    return result
+
+
+def main() -> None:
+    clearml_poc.clearml_init(task_name="NERtrieve R-Precision Evaluation prediction", project_name=DATASET_PROJECT)
+    mlp_id = FineTuneLLM.mlp_head_model_id_from_clearml
+    metadata = load_metadata()
+    embeddings = load_embeddings()
+    ft_to_ids = calc_fine_type_to_ids(metadata)
+    ft_embeds = embed_fine_types(ft_to_ids, mlp_id)
+    evaluator = MultiVecorRPrecision(
+        embeddings=embeddings,
+        fine_type_embeddings=ft_embeds,
+        fine_type_to_ids=ft_to_ids,
+    )
+    evaluator.evaluate()
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/forwarding/nertrieve/forward_llm_mlp_nertrieve.py
+++ b/evaluate_with_extraction/forwarding/nertrieve/forward_llm_mlp_nertrieve.py
@@ -1,0 +1,131 @@
+import os
+import json
+from typing import Dict, List, Tuple
+
+import torch
+from clearml import Dataset
+from tqdm import tqdm
+
+import clearml_poc
+import clearml_helper
+from llm_interface import LLMInterface
+from contrastive.args import Arguments, FineTuneLLM
+from contrastive import fewnerd_processor
+
+BATCH_SIZE = 10
+MAX_BATCHES = 40  # for debugging
+
+
+def load_dataset() -> Dict[str, Dict]:
+    ds = Dataset.get(dataset_name="nertrieve_test_ir_base_combined.json", dataset_project="nertrieve_pipeline")
+    path = os.path.join(ds.get_local_copy(), "nertrieve_test_ir_base_combined.json")
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def process_batch_llm(
+    batch: List[Tuple[str, Dict]],
+    llm: LLMInterface,
+    layer: str,
+    args: Arguments,
+    device: torch.device,
+) -> Tuple[List[torch.Tensor], List[str]]:
+    sentences = [record["sentence"] for _, record in batch]
+    tokens = llm.tokenize(sentences).to(device)
+
+    with torch.no_grad():
+        hidden = llm.get_llm_at_layer(tokens, layer)
+
+    llm_reprs: List[torch.Tensor] = []
+    owners: List[str] = []
+
+    for (text_id, record), h in zip(batch, hidden):
+        for ent in record.get("predicted", []):
+            indices = (ent["start"], ent["end"])
+            if ent["end"] == ent["start"]:
+                continue
+            tok_idx = llm.token_indices_given_text_indices(record["sentence"], indices)
+            start = h[tok_idx[0] - 1]
+            end = h[tok_idx[1]]
+            repr_tensor = fewnerd_processor.choose_llm_representation(
+                end.cpu().tolist(), start.cpu().tolist(), input_tokens=args.input_tokens
+            ).to(device)
+            llm_reprs.append(repr_tensor)
+            owners.append(text_id)
+
+    return llm_reprs, owners
+
+
+def process_batch_mlp(
+    llm_reprs: List[torch.Tensor],
+    owners: List[str],
+    mlp: torch.nn.Module,
+    device: torch.device,
+) -> Dict[str, List[List[float]]]:
+    mlp.eval()
+
+    batch_result: Dict[str, List[List[float]]] = {}
+    if llm_reprs:
+        batch_tensor = torch.stack(llm_reprs).to(device)
+        with torch.no_grad():
+            mlp_out = mlp(batch_tensor).cpu().tolist()
+        for oid, emb in zip(owners, mlp_out):
+            batch_result.setdefault(str(oid), []).append(emb)
+
+    return batch_result
+
+
+def main():
+    clearml_poc.clearml_init(
+        task_name="NERtrieve LLM+MLP forward",
+        project_name="nertrieve_pipeline",
+        requirements=["transformers==4.46.2", "accelerate"],
+    )
+
+    args = Arguments()
+    clearml_poc.clearml_connect_hyperparams(args, "general")
+    llm_args = FineTuneLLM()
+    clearml_poc.clearml_connect_hyperparams(llm_args, "llm_args")
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    llm = LLMInterface(llm_id=llm_args.llm_id, max_llm_layer=llm_args.max_llm_layer)
+    mlp = clearml_helper.get_mlp_by_id(llm_args.mlp_head_model_id_from_clearml, device=device)
+    mlp = mlp.float()
+    llm.model.eval()
+    mlp.eval()
+
+    records = load_dataset()
+
+    result: Dict[str, List[List[float]]] = {}
+    batch: List[Tuple[str, Dict]] = []
+    batches_done = 0
+
+    for text_id, record in tqdm(records.items()):
+        batch.append((text_id, record))
+        if len(batch) >= BATCH_SIZE:
+            llm_reprs, owners = process_batch_llm(batch, llm, llm_args.layer, args, device)
+            batch_result = process_batch_mlp(llm_reprs, owners, mlp, device)
+            for k, v in batch_result.items():
+                result.setdefault(k, []).extend(v)
+            batch = []
+            batches_done += 1
+
+    if batch and batches_done:
+        llm_reprs, owners = process_batch_llm(batch, llm, llm_args.layer, args, device)
+        batch_result = process_batch_mlp(llm_reprs, owners, mlp, device)
+        for k, v in batch_result.items():
+            result.setdefault(k, []).extend(v)
+
+    output_path = "llm_mlp_embeddings.pth"
+    torch.save(result, output_path)
+
+    cl_ds = Dataset.create(dataset_name=output_path, dataset_project="nertrieve_pipeline")
+    cl_ds.add_files(path=output_path)
+    cl_ds.add_tags([output_path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/forwarding/nertrieve/forward_llm_mlp_nertrieve_gold.py
+++ b/evaluate_with_extraction/forwarding/nertrieve/forward_llm_mlp_nertrieve_gold.py
@@ -1,0 +1,131 @@
+import os
+import json
+from typing import Dict, List, Tuple
+
+import torch
+from clearml import Dataset
+from tqdm import tqdm
+
+import clearml_poc
+import clearml_helper
+from llm_interface import LLMInterface
+from contrastive.args import Arguments, FineTuneLLM
+from contrastive import fewnerd_processor
+
+BATCH_SIZE = 15
+MAX_BATCHES = 40  # for debugging
+
+
+def load_dataset() -> Dict[str, Dict]:
+    ds = Dataset.get(dataset_name="nertrieve_test_ir_base_combined.json", dataset_project="nertrieve_pipeline")
+    path = os.path.join(ds.get_local_copy(), "nertrieve_test_ir_base_combined.json")
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def process_batch_llm(
+    batch: List[Tuple[str, Dict]],
+    llm: LLMInterface,
+    layer: str,
+    args: Arguments,
+    device: torch.device,
+) -> Tuple[List[torch.Tensor], List[str]]:
+    sentences = [record["sentence"] for _, record in batch]
+    tokens = llm.tokenize(sentences).to(device)
+
+    with torch.no_grad():
+        hidden = llm.get_llm_at_layer(tokens, layer)
+
+    llm_reprs: List[torch.Tensor] = []
+    owners: List[str] = []
+
+    for (text_id, record), h in zip(batch, hidden):
+        for ent in record.get("gold", []):
+            indices = (ent["start"], ent["end"])
+            if ent["end"] == ent["start"]:
+                continue
+            tok_idx = llm.token_indices_given_text_indices(record["sentence"], indices)
+            start = h[tok_idx[0] - 1]
+            end = h[tok_idx[1]]
+            repr_tensor = fewnerd_processor.choose_llm_representation(
+                end.cpu().tolist(), start.cpu().tolist(), input_tokens=args.input_tokens
+            ).to(device)
+            llm_reprs.append(repr_tensor)
+            owners.append(text_id)
+
+    return llm_reprs, owners
+
+
+def process_batch_mlp(
+    llm_reprs: List[torch.Tensor],
+    owners: List[str],
+    mlp: torch.nn.Module,
+    device: torch.device,
+) -> Dict[str, List[List[float]]]:
+    mlp.eval()
+
+    batch_result: Dict[str, List[List[float]]] = {}
+    if llm_reprs:
+        batch_tensor = torch.stack(llm_reprs).to(device)
+        with torch.no_grad():
+            mlp_out = mlp(batch_tensor).cpu().tolist()
+        for oid, emb in zip(owners, mlp_out):
+            batch_result.setdefault(str(oid), []).append(emb)
+
+    return batch_result
+
+
+def main():
+    clearml_poc.clearml_init(
+        task_name="NERtrieve LLM+MLP forward GOLD",
+        project_name="nertrieve_pipeline",
+        requirements=["transformers==4.46.2", "accelerate"],
+    )
+
+    args = Arguments()
+    clearml_poc.clearml_connect_hyperparams(args, "general")
+    llm_args = FineTuneLLM()
+    clearml_poc.clearml_connect_hyperparams(llm_args, "llm_args")
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    llm = LLMInterface(llm_id=llm_args.llm_id, max_llm_layer=llm_args.max_llm_layer)
+    mlp = clearml_helper.get_mlp_by_id(llm_args.mlp_head_model_id_from_clearml, device=device)
+    mlp = mlp.float()
+    llm.model.eval()
+    mlp.eval()
+
+    records = load_dataset()
+
+    result: Dict[str, List[List[float]]] = {}
+    batch: List[Tuple[str, Dict]] = []
+    batches_done = 0
+
+    for text_id, record in tqdm(records.items()):
+        batch.append((text_id, record))
+        if len(batch) >= BATCH_SIZE:
+            llm_reprs, owners = process_batch_llm(batch, llm, llm_args.layer, args, device)
+            batch_result = process_batch_mlp(llm_reprs, owners, mlp, device)
+            for k, v in batch_result.items():
+                result.setdefault(k, []).extend(v)
+            batch = []
+            batches_done += 1
+
+    if batch and batches_done:
+        llm_reprs, owners = process_batch_llm(batch, llm, llm_args.layer, args, device)
+        batch_result = process_batch_mlp(llm_reprs, owners, mlp, device)
+        for k, v in batch_result.items():
+            result.setdefault(k, []).extend(v)
+
+    output_path = "llm_mlp_embeddings_gold.pth"
+    torch.save(result, output_path)
+
+    cl_ds = Dataset.create(dataset_name=output_path, dataset_project="nertrieve_pipeline")
+    cl_ds.add_files(path=output_path)
+    cl_ds.add_tags([output_path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/forwarding/nertrieve/forward_nertrieve_e5_mistral.py
+++ b/evaluate_with_extraction/forwarding/nertrieve/forward_nertrieve_e5_mistral.py
@@ -1,0 +1,53 @@
+import os
+import json
+from typing import Dict
+
+import torch
+from clearml import Dataset
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from evaluate_with_extraction.forwarding.sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
+
+EMBEDDER_ID = "intfloat/e5-mistral-7b-instruct"
+
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+DATASET_PROJECT = "nertrieve_pipeline"
+OUTPUT_FILE = "sentence_embeddings_e5.pth"
+
+
+def load_dataset() -> Dict[str, Dict]:
+    ds = Dataset.get(dataset_name=DATASET_NAME, dataset_project=DATASET_PROJECT)
+    path = os.path.join(ds.get_local_copy(), DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def upload_result(path: str) -> None:
+    cl_ds = Dataset.create(dataset_name=path, dataset_project=DATASET_PROJECT)
+    cl_ds.add_files(path=path)
+    cl_ds.add_tags([path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="NERtrieve sentence embedder forward E5",
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate", "einops"],
+    )
+
+    embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)
+
+    records = load_dataset()
+    result = forward_dataset(records, embedder, batch_size=BATCH_SIZE)
+
+    torch.save(result, OUTPUT_FILE)
+
+    upload_result(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate_with_extraction/forwarding/nertrieve/forward_nertrieve_nv_embed_v2.py
+++ b/evaluate_with_extraction/forwarding/nertrieve/forward_nertrieve_nv_embed_v2.py
@@ -1,0 +1,56 @@
+import os
+import json
+from typing import Dict
+
+import torch
+from clearml import Dataset
+
+import clearml_poc
+from sentence_embedder import SentenceEmbedder
+from evaluate_with_extraction.forwarding.sentence_embedder_forwarder import forward_dataset, BATCH_SIZE
+
+# ID of the sentence embedder used for forwarding
+EMBEDDER_ID = "nvidia/NV-Embed-v2"
+
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+DATASET_PROJECT = "nertrieve_pipeline"
+OUTPUT_FILE = "sentence_embeddings_nv.pth"
+
+
+def load_dataset() -> Dict[str, Dict]:
+    """Download the extraction dataset from ClearML and return it."""
+    ds = Dataset.get(dataset_name=DATASET_NAME, dataset_project=DATASET_PROJECT)
+    path = os.path.join(ds.get_local_copy(), DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Dict[str, Dict] = json.load(fh)
+    return data
+
+
+def upload_result(path: str) -> None:
+    """Upload the resulting embedding dataset to ClearML."""
+    cl_ds = Dataset.create(dataset_name=path, dataset_project=DATASET_PROJECT)
+    cl_ds.add_files(path=path)
+    cl_ds.add_tags([path])
+    cl_ds.upload()
+    cl_ds.finalize()
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="NERtrieve sentence embedder forward NV",
+        project_name=DATASET_PROJECT,
+        requirements=["transformers==4.46.2", "sentence_transformers", "accelerate", "einops"],
+    )
+
+    embedder = SentenceEmbedder(llm_id=EMBEDDER_ID)
+
+    records = load_dataset()
+    result = forward_dataset(records, embedder, batch_size=BATCH_SIZE)
+
+    torch.save(result, OUTPUT_FILE)
+
+    upload_result(OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement sentence and LLM+MLP forwarding for the NERtrieve dataset
- add evaluators for NV-Embed, E5, BM25 and MLP embeddings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687ba98a5144832fb673a794640ef6b8