### PR TITLE
Add evaluator for last textual entity embeddings

### DIFF
--- a/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_prediciton_last.py
+++ b/evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_prediciton_last.py
@@ -1,0 +1,117 @@
+import json
+import os
+from collections import defaultdict
+from typing import Dict, List, Set
+
+import torch
+from clearml import Dataset
+from tqdm import tqdm
+
+import clearml_poc
+import clearml_helper
+from llm_interface import LLMInterface
+from contrastive import fewnerd_processor
+from contrastive.args import Arguments, FineTuneLLM
+from clearml_pipelines.nertreieve_dataset import nertrieve_processor
+from evaluate_with_extraction.evaluation.multi_vecor_r_precision import MultiVecorRPrecision
+
+DATASET_PROJECT = "nertrieve_pipeline"
+DATASET_NAME = "nertrieve_test_ir_base_combined.json"
+
+
+def _load_dataset(name: str) -> str:
+    ds = Dataset.get(dataset_name=name, dataset_project=DATASET_PROJECT)
+    return os.path.join(ds.get_local_copy(), name)
+
+
+def load_last_embeddings(metadata: Dict[str, Dict]) -> Dict[str, List[torch.Tensor]]:
+    """Load embeddings keeping only the last case-insensitive mention per text."""
+    path = _load_dataset("llm_mlp_embeddings.pth")
+    data = torch.load(path)
+    result: Dict[str, List[torch.Tensor]] = {}
+    for tid, emb_list in tqdm(data.items(), desc="Loading embeddings"):
+        preds = metadata.get(tid, {}).get("predicted", [])
+        last_index: Dict[str, int] = {}
+        for idx, ent in enumerate(preds):
+            text = ent.get("text")
+            if text is None:
+                sent = metadata[tid].get("sentence", "")
+                text = sent[ent.get("start", 0): ent.get("end", 0)]
+            last_index[text.lower()] = idx
+        filtered: List[torch.Tensor] = []
+        for idx, ent in enumerate(preds):
+            text = ent.get("text")
+            if text is None:
+                sent = metadata[tid].get("sentence", "")
+                text = sent[ent.get("start", 0): ent.get("end", 0)]
+            if last_index.get(text.lower()) == idx and idx < len(emb_list):
+                filtered.append(torch.tensor(emb_list[idx], dtype=torch.float))
+        result[tid] = filtered
+    return result
+
+
+def load_metadata() -> Dict[str, Dict]:
+    path = _load_dataset(DATASET_NAME)
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def calc_fine_type_to_ids(metadata: Dict[str, Dict]) -> Dict[str, Set[str]]:
+    mapping: Dict[str, Set[str]] = defaultdict(set)
+    for tid, record in metadata.items():
+        for g in record.get("gold", []):
+            mapping[g["fine_type"]].add(tid)
+    return mapping
+
+
+def embed_fine_types(fine_type_to_ids: Dict[str, Set[str]], mlp_id: str) -> Dict[str, torch.Tensor]:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    mlp = clearml_helper.get_mlp_by_id(mlp_id, device=device)
+    args: Arguments = clearml_helper.get_args_by_mlp_id(mlp_id)
+    llm = LLMInterface(llm_id=FineTuneLLM.llm_id, max_llm_layer=FineTuneLLM.max_llm_layer)
+    layer = FineTuneLLM.layer
+    name_map = nertrieve_processor.type_to_name()
+
+    result = {}
+    for fine_type in fine_type_to_ids.keys():
+        readable = name_map.get(fine_type, fine_type)
+        tokens = llm.tokenize(readable).to(device)
+        with torch.no_grad():
+            hidden = llm.get_llm_at_layer(tokens, layer=layer)
+        start = hidden[0, 0]
+        end = hidden[0, -1]
+        rep = fewnerd_processor.choose_llm_representation(
+            end=end.cpu().tolist(), start=start.cpu().tolist(), input_tokens=args.input_tokens
+        )
+        with torch.no_grad():
+            emb = mlp(rep.to(device)).cpu()
+        result[fine_type] = emb
+    return result
+
+
+class NertrieveRPrecisionPredictionLast:
+    def __init__(self) -> None:
+        self.metadata = load_metadata()
+        self.embeddings = load_last_embeddings(self.metadata)
+        self.ft_to_ids = calc_fine_type_to_ids(self.metadata)
+        self.ft_embeds = embed_fine_types(self.ft_to_ids, FineTuneLLM.mlp_head_model_id_from_clearml)
+        self.evaluator = MultiVecorRPrecision(
+            embeddings=self.embeddings,
+            fine_type_embeddings=self.ft_embeds,
+            fine_type_to_ids=self.ft_to_ids,
+        )
+
+    def evaluate(self):
+        return self.evaluator.evaluate("last text")
+
+
+def main() -> None:
+    clearml_poc.clearml_init(
+        task_name="NERtrieve R-Precision Evaluation prediction last text",
+        project_name=DATASET_PROJECT,
+    )
+    NertrieveRPrecisionPredictionLast().evaluate()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `NertrieveRPrecisionPredictionLast` to evaluate using only the last
  case-insensitive mention of each entity
- add helper `load_last_embeddings` to filter embeddings

## Testing
- `python -m py_compile evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_prediciton_last.py`
- `python -m py_compile evaluate_with_extraction/evaluation/nertrieve/nertrieve_r_precision_prediciton.py`


------
https://chatgpt.com/codex/tasks/task_e_6888d68953a4832f815dec91c8666389