### PR TITLE
feat: batch extraction for fewnerd demo

### DIFF
--- a/demo/cascade_llm_entity_extractor.py
+++ b/demo/cascade_llm_entity_extractor.py
@@ -18,7 +18,13 @@ from typing import List, Tuple, Dict
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
 
-__all__ = ["load_cascadener", "predict_spans", "align_to_original", "extract_entities"]
+__all__ = [
+    "load_cascadener",
+    "predict_spans",
+    "predict_spans_batch",
+    "align_to_original",
+    "extract_entities",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -181,4 +187,24 @@ def predict_spans(
         out[0][enc["input_ids"].shape[1]:], skip_special_tokens=True
     )
     return align_to_original(sentence, generated)
+
+
+def predict_spans_batch(
+    sentences: List[str],
+    tokenizer,
+    model,
+    *,
+    max_new_tokens: int = 2096,
+) -> List[List[Dict]]:
+    """Batch version of :func:`predict_spans` for multiple sentences."""
+    prompts = [build_prompt(s, tokenizer) for s in sentences]
+    enc = tokenizer(prompts, return_tensors="pt", padding=True).to(model.device)
+    input_lens = (enc["input_ids"] != tokenizer.pad_token_id).sum(dim=1)
+    out = model.generate(**enc, max_new_tokens=max_new_tokens)
+    preds: List[List[Dict]] = []
+    for i, sent in enumerate(sentences):
+        gen_tokens = out[i][input_lens[i]:]
+        gen_text = tokenizer.decode(gen_tokens, skip_special_tokens=True)
+        preds.append(align_to_original(sent, gen_text))
+    return preds
 

--- a/demo/extracting_entities_fewnerd.py
+++ b/demo/extracting_entities_fewnerd.py
@@ -25,7 +25,8 @@ Run the script with::
 
     python extracting_entities_fewnerd.py --output fewnerd_entities.json
 
-Use ``--limit`` to process only the first ``N`` sentences for quicker demos.
+Use ``--limit`` to process only the first ``N`` sentences for quicker demos and
+``--batch-size`` to control how many sentences are processed at once.
 """
 
 from __future__ import annotations
@@ -38,7 +39,7 @@ from typing import List, Sequence, Tuple
 
 from datasets import load_dataset
 
-from cascade_llm_entity_extractor import load_cascadener, predict_spans
+from cascade_llm_entity_extractor import load_cascadener, predict_spans_batch
 from fuzzy_span_recall import count_fuzzy_matches
 
 # ---------------------------------------------------------------------------
@@ -109,6 +110,12 @@ def main() -> None:
         default=None,
         help="Process only the first N sentences (for quick demos)",
     )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=8,
+        help="Number of sentences to process at once",
+    )
     args = parser.parse_args()
 
     dataset = load_dataset("DFKI-SLT/few-nerd", "supervised")
@@ -120,38 +127,42 @@ def main() -> None:
     total_gold = 0
     total_matched = 0
 
-    all_examples = itertools.chain(
-        dataset["train"], dataset["validation"], dataset["test"]
+    all_examples = itertools.islice(
+        itertools.chain(dataset["train"], dataset["validation"], dataset["test"]),
+        args.limit,
     )
-    for example in itertools.islice(all_examples, args.limit):
-        tokens = example["tokens"]
-        text = " ".join(tokens)
-        tags = [label_names[t] for t in example["ner_tags"]]
-        gold_spans = tags_to_spans(tokens, tags)
-
-        pred_spans = predict_spans(text, tokenizer, model)
-
-        gold_texts = [text[start:end] for start, end, _ in gold_spans]
-        pred_texts = [p["text"] for p in pred_spans]
-        matched, gold_count = count_fuzzy_matches(gold_texts, pred_texts)
-        total_matched += matched
-        total_gold += gold_count
-
-        record = {
-            "id": str(uuid.uuid4()),
-            "sentence": text,
-            "gold": [
-                {
-                    "text": text[start:end],
-                    "start": start,
-                    "end": end,
-                    "label": label,
-                }
-                for start, end, label in gold_spans
-            ],
-            "predicted": pred_spans,
-        }
-        records.append(record)
+    while True:
+        batch = list(itertools.islice(all_examples, args.batch_size))
+        if not batch:
+            break
+        texts = [" ".join(ex["tokens"]) for ex in batch]
+        tags_batch = [[label_names[t] for t in ex["ner_tags"]] for ex in batch]
+        gold_batch = [
+            tags_to_spans(ex["tokens"], tags)
+            for ex, tags in zip(batch, tags_batch)
+        ]
+        pred_batch = predict_spans_batch(texts, tokenizer, model)
+        for text, gold_spans, pred_spans in zip(texts, gold_batch, pred_batch):
+            gold_texts = [text[start:end] for start, end, _ in gold_spans]
+            pred_texts = [p["text"] for p in pred_spans]
+            matched, gold_count = count_fuzzy_matches(gold_texts, pred_texts)
+            total_matched += matched
+            total_gold += gold_count
+            record = {
+                "id": str(uuid.uuid4()),
+                "sentence": text,
+                "gold": [
+                    {
+                        "text": text[start:end],
+                        "start": start,
+                        "end": end,
+                        "label": label,
+                    }
+                    for start, end, label in gold_spans
+                ],
+                "predicted": pred_spans,
+            }
+            records.append(record)
 
     recall = total_matched / total_gold if total_gold else 0.0
 


### PR DESCRIPTION
## Summary
- add `predict_spans_batch` for batched LLM span extraction
- process FewNERD dataset in configurable batches via `--batch-size`

## Testing
- `python -m py_compile demo/cascade_llm_entity_extractor.py demo/extracting_entities_fewnerd.py`
- `python demo/extracting_entities_fewnerd.py --limit 1 --batch-size 1` *(fails: ModuleNotFoundError: No module named 'datasets')*
- `pip install datasets transformers torch -q` *(fails: Could not find a version that satisfies the requirement datasets)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0fe4af70832fb6b37beea065dc44