### PR TITLE
Fix span detection for simple tag scheme

### DIFF
--- a/demo/extracting_entities_fewnerd.py
+++ b/demo/extracting_entities_fewnerd.py
@@ -46,7 +46,13 @@ from fuzzy_span_recall import count_fuzzy_matches
 # ---------------------------------------------------------------------------
 
 def tags_to_spans(tokens: Sequence[str], tags: Sequence[str]) -> List[Tuple[int, int, str]]:
-    """Convert BIO tags to character spans."""
+    """Convert token-level tags to character spans.
+
+    The dataset uses a simple tagging scheme where each token is either
+    assigned a label or the string ``"O"``.  Consecutive tokens with the same
+    non-``"O"`` label belong to the same span.
+    """
+
     spans: List[Tuple[int, int, str]] = []
     current_label: str | None = None
     start_char: int | None = None
@@ -57,17 +63,18 @@ def tags_to_spans(tokens: Sequence[str], tags: Sequence[str]) -> List[Tuple[int,
         token_end = token_start + len(token)
         offset = token_end + 1  # account for joining spaces
 
-        if tag.startswith("B-"):
-            if current_label is not None:
-                spans.append((start_char, prev_end, current_label))
-            current_label = tag[2:]
-            start_char = token_start
-        elif tag.startswith("I-") and current_label == tag[2:]:
-            pass
-        else:
+        if tag == "O":
             if current_label is not None:
                 spans.append((start_char, prev_end, current_label))
                 current_label = None
+        else:
+            if current_label is None:
+                current_label = tag
+                start_char = token_start
+            elif tag != current_label:
+                spans.append((start_char, prev_end, current_label))
+                current_label = tag
+                start_char = token_start
         prev_end = token_end
 
     if current_label is not None:


### PR DESCRIPTION
## Summary
- handle datasets where tags are labels or `O`, merging consecutive identical labels into a single span

## Testing
- `python -m py_compile demo/extracting_entities_fewnerd.py`
- `python - <<'PY'
import ast
from pathlib import Path
import typing
source = Path('demo/extracting_entities_fewnerd.py').read_text()
module = ast.parse(source)
func_node = next(node for node in module.body if isinstance(node, ast.FunctionDef) and node.name=='tags_to_spans')
code = compile(ast.Module(body=[func_node], type_ignores=[]), filename='<ast>', mode='exec')
ns = {'Sequence': typing.Sequence, 'List': typing.List, 'Tuple': typing.Tuple}
exec(code, ns)

tokens = list('abcdefghijkl')
tags = ['O','O','person','O','O','O','person','person','O','person','person','O']
print(ns['tags_to_spans'](tokens, tags))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac894f67e8832fb645ec6fd758e1e0