### PR TITLE
Fix span detection for simple tag scheme

### DIFF
--- a/demo/extracting_entities_fewnerd.py
+++ b/demo/extracting_entities_fewnerd.py
@@ -46,32 +46,47 @@ from fuzzy_span_recall import count_fuzzy_matches
 # ---------------------------------------------------------------------------
 
 def tags_to_spans(tokens: Sequence[str], tags: Sequence[str]) -> List[Tuple[int, int, str]]:
-    """Convert BIO tags to character spans."""
+    """Convert token-level tags to character spans.
+
+    The dataset uses a simple tagging scheme where each token is either
+    assigned a label or the string ``"O"``.  Consecutive tokens with the same
+    non-``"O"`` label belong to the same span.
+    """
+
     spans: List[Tuple[int, int, str]] = []
     current_label: str | None = None
-    start_char: int | None = None
+    prev_tag = "O"
+    char_pos = 0
+    span_start = 0
+    span_end = 0
 
-    offset = 0
-    for token, tag in zip(tokens, tags):
-        token_start = offset
-        token_end = token_start + len(token)
-        offset = token_end + 1  # account for joining spaces
+    def flush() -> None:
+        nonlocal current_label, span_start, span_end
+        if current_label is not None:
+            spans.append((span_start, span_end, current_label))
+            current_label = None
 
-        if tag.startswith("B-"):
-            if current_label is not None:
-                spans.append((start_char, prev_end, current_label))
-            current_label = tag[2:]
-            start_char = token_start
-        elif tag.startswith("I-") and current_label == tag[2:]:
-            pass
+    for idx, (token, tag) in enumerate(zip(tokens, tags)):
+        token_start = char_pos
+        char_pos += len(token)
+        token_end = char_pos
+        if idx < len(tokens) - 1:
+            char_pos += 1  # account for joining spaces
+
+        if tag != "O":
+            if tag == prev_tag and current_label is not None:
+                span_end = token_end
+            else:
+                flush()
+                current_label = tag
+                span_start = token_start
+                span_end = token_end
+            prev_tag = tag
         else:
-            if current_label is not None:
-                spans.append((start_char, prev_end, current_label))
-                current_label = None
-        prev_end = token_end
+            flush()
+            prev_tag = "O"
 
-    if current_label is not None:
-        spans.append((start_char, prev_end, current_label))
+    flush()
     return spans
 
 


### PR DESCRIPTION
## Summary
- handle datasets where tags are labels or `O`, merging consecutive identical labels into a single span using evaluation script logic

## Testing
- `python -m py_compile demo/extracting_entities_fewnerd.py`
- `python - <<'PY'
import ast
from pathlib import Path
import typing
source = Path('demo/extracting_entities_fewnerd.py').read_text()
module = ast.parse(source)
func_node = next(node for node in module.body if isinstance(node, ast.FunctionDef) and node.name=='tags_to_spans')
code = compile(ast.Module(body=[func_node], type_ignores=[]), filename='<ast>', mode='exec')
ns = {'Sequence': typing.Sequence, 'List': typing.List, 'Tuple': typing.Tuple}
exec(code, ns)

tokens = list('abcdefghijkl')
tags = ['O','O','person','O','O','O','person','person','O','person','person','O']
print(ns['tags_to_spans'](tokens, tags))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac894f67e8832fb645ec6fd758e1e0