### PR TITLE
Refactor demo scripts and document JSON schemas

### DIFF
--- a/demo/cascade_llm_entity_extractor.py
+++ b/demo/cascade_llm_entity_extractor.py
@@ -18,7 +18,14 @@ from typing import List, Tuple, Dict
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
 
-__all__ = ["load_cascadener", "predict_spans_batch", "align_to_original", "extract_entities"]
+__all__ = [
+    "load_cascadener",
+    "build_prompt",
+    "predict_spans",
+    "predict_spans_batch",
+    "align_to_original",
+    "extract_entities",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +73,13 @@ def build_prompt(sentence: str, tokenizer) -> str:
 # ---------------------------------------------------------------------------
 
 def _is_open(text: str, i: int, inside: bool) -> bool:
+    """Return ``True`` if ``##`` at position ``i`` opens a span.
+
+    The extractor occasionally produces nested ``##`` markers.  When we
+    encounter ``##`` while already inside a span we only treat it as opening
+    another span if the following character is alphanumeric.
+    """
+
     if not inside:
         return True
     nxt = i + 2
@@ -119,11 +133,23 @@ def extract_entities(text: str, longest_only: bool = False) -> List[Tuple[str, i
 
 
 def _find_next(hay: str, needle: str, start: int) -> Tuple[int, int]:
+    """Return the ``(start, end)`` of the next ``needle`` in ``hay``.
+
+    ``start`` specifies the offset from which to search.  ``(-1, -1)`` is
+    returned when ``needle`` is not found.
+    """
+
     k = hay.find(needle, start)
     return (k, k + len(needle)) if k != -1 else (-1, -1)
 
 
 def _remove_nested(spans: List[Dict]) -> List[Dict]:
+    """Remove spans fully contained within other spans.
+
+    When the model marks overlapping entities we keep only the outer-most span
+    at each position.  The returned list is sorted by ``start`` offset.
+    """
+
     keep: List[Dict] = []
     for sp in sorted(spans, key=lambda d: d["end"] - d["start"], reverse=True):
         if not any(sp["start"] >= k["start"] and sp["end"] <= k["end"] for k in keep):
@@ -154,6 +180,23 @@ def align_to_original(
 
     return _remove_nested(out)
 
+
+def predict_spans(
+    sentence: str,
+    tokenizer,
+    model,
+    *,
+    max_new_tokens: int = 2096,
+) -> List[Dict]:
+    """Predict entity spans for a single ``sentence``.
+
+    This thin wrapper exists for convenience in demos where only one sentence
+    needs to be processed.
+    """
+
+    return predict_spans_batch(
+        [sentence], tokenizer, model, max_new_tokens=max_new_tokens
+    )[0]
 
 
 def predict_spans_batch(

--- a/demo/extracting_entities_fewnerd.py
+++ b/demo/extracting_entities_fewnerd.py
@@ -91,10 +91,12 @@ def tags_to_spans(tokens: Sequence[str], tags: Sequence[str]) -> List[Tuple[int,
 
 
 # ---------------------------------------------------------------------------
-# Entry point
+# Dataset and extraction helpers
 # ---------------------------------------------------------------------------
 
-def main() -> None:
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--output",
@@ -107,60 +109,120 @@ def main() -> None:
         default=100,
         help="Number of sentences to process at once",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional limit on number of sentences processed",
+    )
+    return parser.parse_args()
+
+
+def load_fewnerd() -> tuple[List[dict], List[str]]:
+    """Download FewNERD and return all examples and label names."""
 
     data_files = {
-	    "train": "hf://datasets/DFKI-SLT/few-nerd@refs/convert/parquet/supervised/train/*.parquet",
-	    "validation": "hf://datasets/DFKI-SLT/few-nerd@refs/convert/parquet/supervised/validation/*.parquet",
-	    "test": "hf://datasets/DFKI-SLT/few-nerd@refs/convert/parquet/supervised/test/*.parquet",
+        "train": "hf://datasets/DFKI-SLT/few-nerd@refs/convert/parquet/supervised/train/*.parquet",
+        "validation": "hf://datasets/DFKI-SLT/few-nerd@refs/convert/parquet/supervised/validation/*.parquet",
+        "test": "hf://datasets/DFKI-SLT/few-nerd@refs/convert/parquet/supervised/test/*.parquet",
     }
     dataset = load_dataset("parquet", data_files=data_files)
     label_names = dataset["train"].features["ner_tags"].feature.names
+    examples = list(dataset["train"]) + list(dataset["validation"]) + list(dataset["test"])
+    return examples, label_names
 
-    tokenizer, model = load_cascadener()
+
+def process_batch(
+    batch: List[dict],
+    label_names: List[str],
+    tokenizer,
+    model,
+) -> tuple[List[dict], int, int]:
+    """Extract entities for a batch of examples.
+
+    Returns
+    -------
+    records: list of dict
+        JSON-serialisable records for each sentence in the batch.
+    matched_total: int
+        Number of gold spans that were fuzzily matched.
+    gold_total: int
+        Number of gold spans considered.
+    """
+
+    texts = [" ".join(ex["tokens"]) for ex in batch]
+    tags_batch = [[label_names[t] for t in ex["ner_tags"]] for ex in batch]
+    gold_batch = [
+        tags_to_spans(ex["tokens"], tags) for ex, tags in zip(batch, tags_batch)
+    ]
+    pred_batch = predict_spans_batch(texts, tokenizer, model)
+
+    records: List[dict] = []
+    matched_total = 0
+    gold_total = 0
+    for text, gold_spans, pred_spans in zip(texts, gold_batch, pred_batch):
+        gold_texts = [text[start:end] for start, end, _ in gold_spans]
+        pred_texts = [p["text"] for p in pred_spans]
+        matched, gold_count = count_fuzzy_matches(gold_texts, pred_texts)
+        matched_total += matched
+        gold_total += gold_count
+        record = {
+            "id": str(uuid.uuid4()),
+            "sentence": text,
+            "gold": [
+                {
+                    "text": text[start:end],
+                    "start": start,
+                    "end": end,
+                    "label": label,
+                }
+                for start, end, label in gold_spans
+            ],
+            "predicted": pred_spans,
+        }
+        records.append(record)
+
+    return records, matched_total, gold_total
+
+
+def extract_entities(
+    examples: List[dict],
+    label_names: List[str],
+    tokenizer,
+    model,
+    batch_size: int,
+) -> tuple[List[dict], float]:
+    """Run extraction over the dataset and compute span recall."""
 
     records: List[dict] = []
     total_gold = 0
     total_matched = 0
 
-    all_examples = list(dataset["train"]) +  list(dataset["validation"]) + list(dataset["test"])
-    batches = list(range(0, len(all_examples), args.batch_size))
-
-    for batch_start_index in tqdm(batches):
-        batch = all_examples[batch_start_index:batch_start_index + args.batch_size]
-        texts = [" ".join(ex["tokens"]) for ex in batch]
-        tags_batch = [[label_names[t] for t in ex["ner_tags"]] for ex in batch]
-        gold_batch = [
-            tags_to_spans(ex["tokens"], tags)
-            for ex, tags in zip(batch, tags_batch)
-        ]
-        pred_batch = predict_spans_batch(texts, tokenizer, model)
-        for text, gold_spans, pred_spans in zip(texts, gold_batch, pred_batch):
-            gold_texts = [text[start:end] for start, end, _ in gold_spans]
-            pred_texts = [p["text"] for p in pred_spans]
-            matched, gold_count = count_fuzzy_matches(gold_texts, pred_texts)
-            total_matched += matched
-            total_gold += gold_count
-            record = {
-                "id": str(uuid.uuid4()),
-                "sentence": text,
-                "gold": [
-                    {
-                        "text": text[start:end],
-                        "start": start,
-                        "end": end,
-                        "label": label,
-                    }
-                    for start, end, label in gold_spans
-                ],
-                "predicted": pred_spans,
-            }
-            records.append(record)
+    for i in tqdm(range(0, len(examples), batch_size)):
+        batch = examples[i : i + batch_size]
+        recs, matched, gold = process_batch(batch, label_names, tokenizer, model)
+        records.extend(recs)
+        total_matched += matched
+        total_gold += gold
 
     recall = total_matched / total_gold if total_gold else 0.0
+    return records, recall
+
+
+def main() -> None:
+    args = parse_args()
+    examples, label_names = load_fewnerd()
+    if args.limit is not None:
+        examples = examples[: args.limit]
+    tokenizer, model = load_cascadener()
+
+    records, recall = extract_entities(
+        examples, label_names, tokenizer, model, args.batch_size
+    )
 
     with open(args.output, "w", encoding="utf8") as f:
         json.dump(records, f, indent=2, ensure_ascii=False)
+
     print(f"Wrote {len(records)} sentences to {args.output}")
     print(f"Span recall: {recall:.3f}")
 

--- a/demo/fewnerd_r_precision_prediction.py
+++ b/demo/fewnerd_r_precision_prediction.py
@@ -8,6 +8,12 @@ to recover the labels.  ``torch`` (or a ``pickle`` fallback) is used to load the
 vectors while ``faiss`` performs the cosine-similarity search.  If ``faiss`` is
 unavailable the script falls back to a small pure-Python implementation.
 
+The ``--entities`` JSON must have the schema produced by
+``extracting_entities_fewnerd.py`` (see that script for details).  The
+``--embeddings`` file stores a ``dict[str, List[List[float]]]`` mapping each
+sentence identifier to the corresponding entity embeddings as written by
+``forward_llm_mlp_fewnerd.py``.
+
 R-precision is calculated by treating each entity as a query and ranking all
 other entities by cosine similarity of their embedding vectors.  The number of
 relevant items ``R`` is equal to the number of entities of the same type minus
@@ -99,16 +105,29 @@ def r_precision(embeddings: List[Sequence[float]], labels: List[str]) -> Tuple[D
     return results, macro
 
 
-def main() -> None:
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--embeddings", default="fewnerd_embeddings.pth", help="Embedding .pth file")
     parser.add_argument("--entities", default="fewnerd_entities.json", help="Original entity JSON")
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    emb_map = torch.load(args.embeddings)
 
-    with open(args.entities, "r", encoding="utf8") as f:
+def load_data(emb_path: str, ent_path: str) -> Tuple[Dict[str, List[Sequence[float]]], Dict[str, dict]]:
+    """Load embedding map and entity records."""
+
+    emb_map = torch.load(emb_path)
+    with open(ent_path, "r", encoding="utf8") as f:
         sent_records = {rec["id"]: rec for rec in json.load(f)}
+    return emb_map, sent_records
+
+
+def gather_embeddings(
+    emb_map: Dict[str, List[Sequence[float]]],
+    sent_records: Dict[str, dict],
+) -> Tuple[List[Sequence[float]], List[str]]:
+    """Flatten embedding dictionary and collect corresponding labels."""
 
     embeddings: List[Sequence[float]] = []
     labels: List[str] = []
@@ -117,7 +136,13 @@ def main() -> None:
         for vec, ent in zip(vecs, gold):
             embeddings.append(vec)
             labels.append(ent["label"])
+    return embeddings, labels
 
+
+def main() -> None:
+    args = parse_args()
+    emb_map, sent_records = load_data(args.embeddings, args.entities)
+    embeddings, labels = gather_embeddings(emb_map, sent_records)
     scores, macro = r_precision(embeddings, labels)
 
     print("R-precision per fine type:")

--- a/demo/forward_llm_mlp_fewnerd.py
+++ b/demo/forward_llm_mlp_fewnerd.py
@@ -2,10 +2,25 @@
 
 This script reads the sentence-level JSON produced by
 ``extracting_entities_fewnerd.py`` and generates an embedding for every gold
-entity span.  The embedding is taken from block 17 of ``Meta‑Llama‑3.1`` and
-projected through an MLP whose architecture mirrors the training-time model in
-``mlp.py``.  The resulting vectors are written as a binary ``.pth`` file mapping
-each sentence identifier to a list of its entity embeddings.
+entity span.  The expected input JSON has the form::
+
+    [
+        {
+            "id": "<uuid>",
+            "sentence": "...",
+            "gold": [
+                {"text": "Barack Obama", "start": 0, "end": 12, "label": "person/actor"},
+                ...
+            ],
+            "predicted": [ ... ]
+        },
+        ...
+    ]
+
+For each gold entity we take the hidden state difference of the start and end
+tokens from block 17 of ``Meta‑Llama‑3.1-8B`` and project it through a small
+MLP.  The resulting vectors are written as a binary ``.pth`` file mapping each
+sentence identifier to a list of its entity embeddings.
 
 Run the script with::
 
@@ -147,16 +162,22 @@ def embed_with_llama(
     return records
 
 
-def main() -> None:
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", default="fewnerd_entities.json", help="Input JSON file")
     parser.add_argument("--output", default="fewnerd_embeddings.pth", help="Output .pth file")
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    with open(args.input, "r", encoding="utf8") as f:
-        sentences = json.load(f)
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+def load_models(device: torch.device):
+    """Load tokenizer, base model and MLP head."""
+
     tokenizer = AutoTokenizer.from_pretrained(
         "meta-llama/Meta-Llama-3.1-8B",
         use_fast=True,
@@ -166,16 +187,33 @@ def main() -> None:
         output_hidden_states=True,
         torch_dtype=torch.float32,
     ).to(device).eval()
-
     mlp_args = MLPArgs()
     mlp = MLP(mlp_args).to(device)
     mlp.load_state_dict(torch.load("entity_head.pth", map_location=device))
     mlp.eval()
+    return tokenizer, model, mlp
+
+
+def load_sentences(path: str) -> List[Dict]:
+    """Read input JSON containing sentence records."""
+
+    with open(path, "r", encoding="utf8") as f:
+        return json.load(f)
+
+
+def main() -> None:
+    args = parse_args()
+    sentences = load_sentences(args.input)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer, model, mlp = load_models(device)
 
     records = embed_with_llama(sentences, tokenizer, model, mlp, device)
 
     torch.save(records, args.output)
-    print(f"Wrote embeddings for {sum(len(v) for v in records.values())} entities to {args.output}")
+    print(
+        f"Wrote embeddings for {sum(len(v) for v in records.values())} entities to {args.output}"
+    )
 
 
 if __name__ == "__main__":

--- a/demo/fuzzy_span_recall.py
+++ b/demo/fuzzy_span_recall.py
@@ -26,10 +26,13 @@ def normalise(text: str) -> str:
 
 
 def jaccard(a: set[str], b: set[str]) -> float:
+    """Return the Jaccard similarity between two token sets."""
     return len(a & b) / len(a | b) if (a | b) else 0.0
 
 
 def is_match(gold: str, pred: str, min_jacc: float = 0.8) -> bool:
+    """Return ``True`` if ``pred`` matches ``gold`` under fuzzy criteria."""
+
     gold_t, pred_t = set(gold.split()), set(pred.split())
     return (
         gold_t <= pred_t


### PR DESCRIPTION
## Summary
- modularize demo scripts into smaller functions with extensive comments
- document JSON input/output schemas and add helpful wrappers like `predict_spans`
- clarify fuzzy matching utilities with docstrings

## Testing
- `python -m py_compile demo/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad89e3d580832fb755c4153e7b449a